### PR TITLE
Add Playwright test for verifying 'Client Work' text visibility

### DIFF
--- a/tests/rozetkaBasket.test.ts
+++ b/tests/rozetkaBasket.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify that the basket is empty on Rozetka', async ({ page }) => {
+  // Navigate to Rozetka website
+  await page.goto('https://rozetka.com.ua/');
+
+  // Click on the basket icon
+  await page.click('a[href*="cart"]');
+
+  // Assert that the basket is empty
+  const emptyBasketMessage = await page.locator('text=Корзина пуста').isVisible();
+  expect(emptyBasketMessage).toBeTruthy();
+});

--- a/tests/verify-client-work.spec.ts
+++ b/tests/verify-client-work.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify "Client Work" text is visible on the page', async ({ page }) => {
+  // Navigate to the EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Click on "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click on "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a Playwright test to verify that the 'Client Work' text is visible on the page after navigating through the EPAM website as per the provided test scenario.